### PR TITLE
Flame v1.2.0 migration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: subosito/flutter-action@v1
         with:
           channel: "stable" # 'dev', 'alpha', default to: 'stable'
-          flutter-version: "2.0.3" # you can also specify exact version of flutter
+          flutter-version: "3.0.1" # you can also specify exact version of flutter
 
       # Get flutter dependencies.
       - run: flutter pub get

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/lib/game/bullet.dart
+++ b/lib/game/bullet.dart
@@ -1,10 +1,10 @@
+import 'package:flame/collisions.dart';
 import 'package:flame/components.dart';
-import 'package:flame/geometry.dart';
 
 import 'enemy.dart';
 
 // This component represent a bullet in game world.
-class Bullet extends SpriteComponent with Hitbox, Collidable {
+class Bullet extends SpriteComponent with CollisionCallbacks {
   // Speed of the bullet.
   double _speed = 450;
 
@@ -28,17 +28,22 @@ class Bullet extends SpriteComponent with Hitbox, Collidable {
 
     // Adding a circular hitbox with radius as 0.4 times
     //  the smallest dimension of this components size.
-    final shape = HitboxCircle(definition: 0.4);
-    addShape(shape);
+    final shape = CircleHitbox.relative(
+      0.4,
+      parentSize: this.size,
+      position: Vector2(size.x / 2, size.y / 2),
+      anchor: Anchor.center,
+    );
+    add(shape);
   }
 
   @override
-  void onCollision(Set<Vector2> intersectionPoints, Collidable other) {
+  void onCollision(Set<Vector2> intersectionPoints, PositionComponent other) {
     super.onCollision(intersectionPoints, other);
 
     // If the other Collidable is Enemy, remove this bullet.
     if (other is Enemy) {
-      this.remove();
+      this.removeFromParent();
     }
   }
 
@@ -52,7 +57,7 @@ class Bullet extends SpriteComponent with Hitbox, Collidable {
     // If bullet crosses the upper boundary of screen
     // mark it to be removed it from the game world.
     if (this.position.y < 0) {
-      remove();
+      removeFromParent();
     }
   }
 }

--- a/lib/game/bullet.dart
+++ b/lib/game/bullet.dart
@@ -31,7 +31,7 @@ class Bullet extends SpriteComponent with CollisionCallbacks {
     final shape = CircleHitbox.relative(
       0.4,
       parentSize: this.size,
-      position: Vector2(size.x / 2, size.y / 2),
+      position: size / 2,
       anchor: Anchor.center,
     );
     add(shape);

--- a/lib/game/enemy.dart
+++ b/lib/game/enemy.dart
@@ -97,7 +97,7 @@ class Enemy extends SpriteComponent
     final shape = CircleHitbox.relative(
       0.8,
       parentSize: this.size,
-      position: Vector2(size.x / 2, size.y / 2),
+      position: size / 2,
       anchor: Anchor.center,
     );
     add(shape);
@@ -123,9 +123,8 @@ class Enemy extends SpriteComponent
       // reduce health by level of bullet times 10.
       _hitPoints -= other.level * 10;
     } else if (other is Player) {
-      // If the other Collidable is Player,
-      // reduce health to zero at once.
-      _hitPoints = 0;
+      // If the other Collidable is Player, destroy.
+      destroy();
     }
   }
 

--- a/lib/game/enemy.dart
+++ b/lib/game/enemy.dart
@@ -1,10 +1,9 @@
 import 'dart:math';
 
-import 'package:flame/geometry.dart';
+import 'package:flame/collisions.dart';
 import 'package:flame/particles.dart';
 import 'package:flame/components.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/painting.dart';
 
 import 'game.dart';
 import 'bullet.dart';
@@ -17,7 +16,7 @@ import '../models/enemy_data.dart';
 
 // This class represent an enemy component.
 class Enemy extends SpriteComponent
-    with KnowsGameSize, Hitbox, Collidable, HasGameRef<SpacescapeGame> {
+    with KnowsGameSize, CollisionCallbacks, HasGameRef<SpacescapeGame> {
   // The speed of this enemy.
   double _speed = 250;
 
@@ -39,9 +38,9 @@ class Enemy extends SpriteComponent
 
   // To display health in game world.
   TextComponent _hpText = TextComponent(
-    '10 HP',
+    text: '10 HP',
     textRenderer: TextPaint(
-      config: TextPaintConfig(
+      style: TextStyle(
         color: Colors.white,
         fontSize: 12,
         fontFamily: 'BungeeInline',
@@ -79,7 +78,7 @@ class Enemy extends SpriteComponent
     _hpText.text = '$_hitPoints HP';
 
     // Sets freeze time to 2 seconds. After 2 seconds speed will be reset.
-    _freezeTimer = Timer(2, callback: () {
+    _freezeTimer = Timer(2, onTick: () {
       _speed = enemyData.speed;
     });
 
@@ -95,8 +94,13 @@ class Enemy extends SpriteComponent
 
     // Adding a circular hitbox with radius as 0.8 times
     // the smallest dimension of this components size.
-    final shape = HitboxCircle(definition: 0.8);
-    addShape(shape);
+    final shape = CircleHitbox.relative(
+      0.8,
+      parentSize: this.size,
+      position: Vector2(size.x / 2, size.y / 2),
+      anchor: Anchor.center,
+    );
+    add(shape);
 
     // As current component is already rotated by pi radians,
     // the text component needs to be again rotated by pi radians
@@ -107,11 +111,11 @@ class Enemy extends SpriteComponent
     _hpText.position = Vector2(50, 80);
 
     // Add as child of current component.
-    addChild(_hpText);
+    add(_hpText);
   }
 
   @override
-  void onCollision(Set<Vector2> intersectionPoints, Collidable other) {
+  void onCollision(Set<Vector2> intersectionPoints, PositionComponent other) {
     super.onCollision(intersectionPoints, other);
 
     if (other is Bullet) {
@@ -132,7 +136,7 @@ class Enemy extends SpriteComponent
       audioPlayer.playSfx('laser1.ogg');
     }));
 
-    this.remove();
+    this.removeFromParent();
 
     // Before dying, register a command to increase
     // player's score by 1.
@@ -145,7 +149,7 @@ class Enemy extends SpriteComponent
     // Generate 20 white circle particles with random speed and acceleration,
     // at current position of this enemy. Each particles lives for exactly
     // 0.1 seconds and will get removed from the game world after that.
-    final particleComponent = ParticleComponent(
+    final particleComponent = ParticleSystemComponent(
       particle: Particle.generate(
         count: 20,
         lifespan: 0.1,
@@ -183,10 +187,10 @@ class Enemy extends SpriteComponent
     this.position += moveDirection * _speed * dt;
 
     // If the enemy leaves the screen, destroy it.
-    if (this.position.y > this.gameSize.y) {
-      remove();
+    if (this.position.y > gameRef.size.y) {
+      removeFromParent();
     } else if ((this.position.x < this.size.x / 2) ||
-        (this.position.x > (this.gameSize.x - size.x / 2))) {
+        (this.position.x > (gameRef.size.x - size.x / 2))) {
       // Enemy is going outside vertical screen bounds, flip its x direction.
       moveDirection.x *= -1;
     }

--- a/lib/game/enemy_manager.dart
+++ b/lib/game/enemy_manager.dart
@@ -14,7 +14,7 @@ import '../models/player_data.dart';
 // This component class takes care of spawning new enemy components
 // randomly from top of the screen. It uses the HasGameRef mixin so that
 // it can add child components.
-class EnemyManager extends BaseComponent
+class EnemyManager extends Component
     with KnowsGameSize, HasGameRef<SpacescapeGame> {
   // The timer which runs the enemy spawner code at regular interval of time.
   late Timer _timer;
@@ -30,10 +30,10 @@ class EnemyManager extends BaseComponent
 
   EnemyManager({required this.spriteSheet}) : super() {
     // Sets the timer to call _spawnEnemy() after every 1 second, until timer is explicitly stops.
-    _timer = Timer(1, callback: _spawnEnemy, repeat: true);
+    _timer = Timer(1, onTick: _spawnEnemy, repeat: true);
 
     // Sets freeze time to 2 seconds. After 2 seconds spawn timer will start again.
-    _freezeTimer = Timer(2, callback: () {
+    _freezeTimer = Timer(2, onTick: () {
       _timer.start();
     });
   }
@@ -43,13 +43,13 @@ class EnemyManager extends BaseComponent
     Vector2 initialSize = Vector2(64, 64);
 
     // random.nextDouble() generates a random number between 0 and 1.
-    // Multiplying it by gameSize.x makes sure that the value remains between 0 and width of screen.
-    Vector2 position = Vector2(random.nextDouble() * gameSize.x, 0);
+    // Multiplying it by gameRef.size.x makes sure that the value remains between 0 and width of screen.
+    Vector2 position = Vector2(random.nextDouble() * gameRef.size.x, 0);
 
     // Clamps the vector such that the enemy sprite remains within the screen.
     position.clamp(
       Vector2.zero() + initialSize / 2,
-      gameSize - initialSize / 2,
+      gameRef.size - initialSize / 2,
     );
 
     // Make sure that we have a valid BuildContext before using it.

--- a/lib/game/game.dart
+++ b/lib/game/game.dart
@@ -20,7 +20,6 @@ import 'bullet.dart';
 import 'command.dart';
 import 'power_ups.dart';
 import 'enemy_manager.dart';
-import 'knows_game_size.dart';
 import 'power_up_manager.dart';
 import 'audio_player_component.dart';
 

--- a/lib/game/knows_game_size.dart
+++ b/lib/game/knows_game_size.dart
@@ -1,9 +1,13 @@
+// IMPORTANT NOTE
+// This class is obsolete since Flame v1.2.0 version
+// This code remains as is as a reference for the YouTube tutorial.
+
 import 'package:flame/components.dart';
 
 // Adding this mixin to any class derived from BaseComponent will make sure that
 // the components gets access to current gameSize. Do not try to access gameSize
 // before your components is added to the game instance.
-mixin KnowsGameSize on BaseComponent {
+mixin KnowsGameSize on Component {
   late Vector2 gameSize;
 
   void onResize(Vector2 newGameSize) {

--- a/lib/game/player.dart
+++ b/lib/game/player.dart
@@ -1,6 +1,6 @@
 import 'dart:math';
 
-import 'package:flame/geometry.dart';
+import 'package:flame/collisions.dart';
 import 'package:flame/particles.dart';
 import 'package:flame/components.dart';
 import 'package:flutter/material.dart';
@@ -18,15 +18,9 @@ import 'audio_player_component.dart';
 
 // This component class represents the player character in game.
 class Player extends SpriteComponent
-    with
-        KnowsGameSize,
-        Hitbox,
-        Collidable,
-        JoystickListener,
-        HasGameRef<SpacescapeGame> {
-  // Controls in which direction player should move. Magnitude of this vector does not matter.
-  // It is just used for getting a direction.
-  Vector2 _moveDirection = Vector2.zero();
+    with KnowsGameSize, CollisionCallbacks, HasGameRef<SpacescapeGame> {
+  // Player joystick
+  JoystickComponent joystick;
 
   // Player health.
   int _health = 100;
@@ -60,6 +54,7 @@ class Player extends SpriteComponent
   }
 
   Player({
+    required this.joystick,
     required this.spaceshipType,
     Sprite? sprite,
     Vector2? position,
@@ -68,9 +63,17 @@ class Player extends SpriteComponent
         super(sprite: sprite, position: position, size: size) {
     // Sets power up timer to 4 seconds. After 4 seconds,
     // multiple bullet will get deactivated.
-    _powerUpTimer = Timer(4, callback: () {
+    _powerUpTimer = Timer(4, onTick: () {
       _shootMultipleBullets = false;
     });
+  }
+
+  // Fill _playerData with defaultData to make sure a null exception is not thrown.
+  // game.dart -> update() -> _playerScore.text = 'Score: ${_player.score}';
+  @override
+  Future<void>? onLoad() {
+    _playerData = PlayerData.fromMap(PlayerData.defaultData);
+    return super.onLoad();
   }
 
   @override
@@ -79,14 +82,19 @@ class Player extends SpriteComponent
 
     // Adding a circular hitbox with radius as 0.8 times
     // the smallest dimension of this components size.
-    final shape = HitboxCircle(definition: 0.8);
-    addShape(shape);
+    final shape = CircleHitbox.relative(
+      0.8,
+      parentSize: this.size,
+      position: Vector2(size.x / 2, size.y / 2),
+      anchor: Anchor.center,
+    );
+    add(shape);
 
     _playerData = Provider.of<PlayerData>(gameRef.buildContext!, listen: false);
   }
 
   @override
-  void onCollision(Set<Vector2> intersectionPoints, Collidable other) {
+  void onCollision(Set<Vector2> intersectionPoints, PositionComponent other) {
     super.onCollision(intersectionPoints, other);
 
     // If other entity is an Enemy, reduce player's health by 10.
@@ -112,16 +120,18 @@ class Player extends SpriteComponent
     // Delta time is the time elapsed since last update. For devices with higher frame rates, delta time
     // will be smaller and for devices with lower frame rates, it will be larger. Multiplying speed with
     // delta time ensure that player speed remains same irrespective of the device FPS.
-    this.position += _moveDirection.normalized() * _spaceship.speed * dt;
+    if (!joystick.delta.isZero()) {
+      position.add(joystick.relativeDelta * _spaceship.speed * dt);
+    }
 
     // Clamp position of player such that the player sprite does not go outside the screen size.
     this.position.clamp(
           Vector2.zero() + this.size / 2,
-          gameSize - this.size / 2,
+          gameRef.size - this.size / 2,
         );
 
     // Adds thruster particles.
-    final particleComponent = ParticleComponent(
+    final particleComponent = ParticleSystemComponent(
       particle: Particle.generate(
         count: 10,
         lifespan: 0.1,
@@ -140,80 +150,39 @@ class Player extends SpriteComponent
     gameRef.add(particleComponent);
   }
 
-  // Changes the current move direction with given new move direction.
-  void setMoveDirection(Vector2 newMoveDirection) {
-    _moveDirection = newMoveDirection;
-  }
+  void joystickAction() {
+    Bullet bullet = Bullet(
+      sprite: gameRef.spriteSheet.getSpriteById(28),
+      size: Vector2(64, 64),
+      position: this.position.clone(),
+      level: _spaceship.level,
+    );
 
-  @override
-  void joystickAction(JoystickActionEvent event) {
-    if (event.id == 0 && event.event == ActionEvent.down) {
-      Bullet bullet = Bullet(
-        sprite: gameRef.spriteSheet.getSpriteById(28),
-        size: Vector2(64, 64),
-        position: this.position.clone(),
-        level: _spaceship.level,
-      );
+    // Anchor it to center and add to game world.
+    bullet.anchor = Anchor.center;
+    gameRef.add(bullet);
 
-      // Anchor it to center and add to game world.
-      bullet.anchor = Anchor.center;
-      gameRef.add(bullet);
+    // Ask audio player to play bullet fire effect.
+    gameRef.addCommand(Command<AudioPlayerComponent>(action: (audioPlayer) {
+      audioPlayer.playSfx('laserSmall_001.ogg');
+    }));
 
-      // Ask audio player to play bullet fire effect.
-      gameRef.addCommand(Command<AudioPlayerComponent>(action: (audioPlayer) {
-        audioPlayer.playSfx('laserSmall_001.ogg');
-      }));
+    // If multiple bullet is on, add two more
+    // bullets rotated +-PI/6 radians to first bullet.
+    if (_shootMultipleBullets) {
+      for (int i = -1; i < 2; i += 2) {
+        Bullet bullet = Bullet(
+          sprite: gameRef.spriteSheet.getSpriteById(28),
+          size: Vector2(64, 64),
+          position: this.position.clone(),
+          level: _spaceship.level,
+        );
 
-      // If multiple bullet is on, add two more
-      // bullets rotated +-PI/6 radians to first bullet.
-      if (_shootMultipleBullets) {
-        for (int i = -1; i < 2; i += 2) {
-          Bullet bullet = Bullet(
-            sprite: gameRef.spriteSheet.getSpriteById(28),
-            size: Vector2(64, 64),
-            position: this.position.clone(),
-            level: _spaceship.level,
-          );
-
-          // Anchor it to center and add to game world.
-          bullet.anchor = Anchor.center;
-          bullet.direction.rotate(i * pi / 6);
-          gameRef.add(bullet);
-        }
+        // Anchor it to center and add to game world.
+        bullet.anchor = Anchor.center;
+        bullet.direction.rotate(i * pi / 6);
+        gameRef.add(bullet);
       }
-    }
-  }
-
-  @override
-  void joystickChangeDirectional(JoystickDirectionalEvent event) {
-    switch (event.directional) {
-      case JoystickMoveDirectional.moveUp:
-        this.setMoveDirection(Vector2(0, -1));
-        break;
-      case JoystickMoveDirectional.moveUpLeft:
-        this.setMoveDirection(Vector2(-1, -1));
-        break;
-      case JoystickMoveDirectional.moveUpRight:
-        this.setMoveDirection(Vector2(1, -1));
-        break;
-      case JoystickMoveDirectional.moveRight:
-        this.setMoveDirection(Vector2(1, 0));
-        break;
-      case JoystickMoveDirectional.moveDown:
-        this.setMoveDirection(Vector2(0, 1));
-        break;
-      case JoystickMoveDirectional.moveDownRight:
-        this.setMoveDirection(Vector2(1, 1));
-        break;
-      case JoystickMoveDirectional.moveDownLeft:
-        this.setMoveDirection(Vector2(-1, 1));
-        break;
-      case JoystickMoveDirectional.moveLeft:
-        this.setMoveDirection(Vector2(-1, 0));
-        break;
-      case JoystickMoveDirectional.idle:
-        this.setMoveDirection(Vector2.zero());
-        break;
     }
   }
 
@@ -241,7 +210,7 @@ class Player extends SpriteComponent
   void reset() {
     _playerData.currentScore = 0;
     this._health = 100;
-    this.position = gameRef.viewport.canvasSize / 2;
+    this.position = gameRef.canvasSize / 2;
   }
 
   // Changes the current spaceship type with given spaceship type.

--- a/lib/game/player.dart
+++ b/lib/game/player.dart
@@ -85,7 +85,7 @@ class Player extends SpriteComponent
     final shape = CircleHitbox.relative(
       0.8,
       parentSize: this.size,
-      position: Vector2(size.x / 2, size.y / 2),
+      position: size / 2,
       anchor: Anchor.center,
     );
     add(shape);

--- a/lib/game/power_up_manager.dart
+++ b/lib/game/power_up_manager.dart
@@ -11,7 +11,7 @@ enum PowerUpTypes { Health, Freeze, Nuke, MultiFire }
 
 // This class/component is responsible for spawning random power ups
 // at random locations in the game world.
-class PowerUpManager extends BaseComponent
+class PowerUpManager extends Component
     with KnowsGameSize, HasGameRef<SpacescapeGame> {
   // Controls the frequency of spawning power ups.
   late Timer _spawnTimer;
@@ -53,11 +53,11 @@ class PowerUpManager extends BaseComponent
 
   PowerUpManager() : super() {
     // Makes sure that a new power up is spawned every 5 seconds.
-    _spawnTimer = Timer(5, callback: _spawnPowerUp, repeat: true);
+    _spawnTimer = Timer(5, onTick: _spawnPowerUp, repeat: true);
 
     // Restarts the spawn timer after 2 seconds are
     // elapsed from start of freeze timer.
-    _freezeTimer = Timer(2, callback: () {
+    _freezeTimer = Timer(2, onTick: () {
       _spawnTimer.start();
     });
   }
@@ -67,15 +67,15 @@ class PowerUpManager extends BaseComponent
   void _spawnPowerUp() {
     Vector2 initialSize = Vector2(64, 64);
     Vector2 position = Vector2(
-      random.nextDouble() * gameSize.x,
-      random.nextDouble() * gameSize.y,
+      random.nextDouble() * gameRef.size.x,
+      random.nextDouble() * gameRef.size.y,
     );
 
     // Clamp so that the power up does not
     // go outside the screen.
     position.clamp(
       Vector2.zero() + initialSize / 2,
-      gameSize - initialSize / 2,
+      gameRef.size - initialSize / 2,
     );
 
     // Returns a random integer from 0 to (PowerUpTypes.values.length - 1).

--- a/lib/game/power_ups.dart
+++ b/lib/game/power_ups.dart
@@ -47,7 +47,7 @@ abstract class PowerUp extends SpriteComponent
     final shape = CircleHitbox.relative(
       0.5,
       parentSize: this.size,
-      position: Vector2(size.x / 2, size.y / 2),
+      position: size / 2,
       anchor: Anchor.center,
     );
     add(shape);

--- a/lib/widgets/overlays/pause_menu.dart
+++ b/lib/widgets/overlays/pause_menu.dart
@@ -70,6 +70,7 @@ class PauseMenu extends StatelessWidget {
               onPressed: () {
                 gameRef.overlays.remove(PauseMenu.ID);
                 gameRef.reset();
+                gameRef.resumeEngine();
 
                 Navigator.of(context).pushReplacement(
                   MaterialPageRoute(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,8 +21,8 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  flame: 1.0.0-releasecandidate.13
-  flame_audio: 1.0.0-rc.1
+  flame: ^1.2.0
+  flame_audio: ^1.1.0
   provider: ^5.0.0
   flutter_carousel_slider: ^1.0.8
   hive: 2.0.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
   flame: ^1.2.0


### PR DESCRIPTION
# Major description of changes:

## SpacescapeGame:
- Dead code **prepare**() and **onResize**() methods due fact that overrides no longer exists in v1.2.0

## Migrate JoystickComponent:
- joystickChangeDirectional() **removed**
- joystickAction() updated, now called by **ButtonComponent**
- Player.update() adapt new **position** calculation.
- Now joystick component is required for **Player** class.
- **ButtonComponent** added instead actions in JoystickComponent.

## KnowsGameSize:
- No longer used in code, remains as is as reference for the YouTube tutorial with note about it in code.
- Migrate for use **gameRef.size** instead.

## Player:
- **onLoad** method added.
- Fill **_playerData** with defaultData to make sure a null exception is not thrown due update in game.dart (**_playerScore.text**).
