### PR TITLE
Fix crash on Windows + PlayData.isEqupped check

### DIFF
--- a/lib/game/audio_player_component.dart
+++ b/lib/game/audio_player_component.dart
@@ -1,4 +1,5 @@
 import 'package:flame/components.dart';
+import 'package:flame/flame.dart';
 import 'package:flame_audio/flame_audio.dart';
 import 'package:provider/provider.dart';
 
@@ -11,17 +12,26 @@ class AudioPlayerComponent extends Component with HasGameRef<SpacescapeGame> {
   Future<void>? onLoad() async {
     FlameAudio.bgm.initialize();
 
-    await FlameAudio.audioCache.loadAll([
-      'laser1.ogg',
-      'powerUp6.ogg',
-      '9. Space Invaders.wav',
-      'laserSmall_001.ogg'
-    ]);
+    await FlameAudio.audioCache
+        .loadAll(['laser1.ogg', 'powerUp6.ogg', 'laserSmall_001.ogg']);
+
+    try {
+      await FlameAudio.audioCache.load(
+        '9. Space Invaders.wav',
+      );
+    } catch (_) {
+      // ignore: avoid_print
+      print('Missing VOiD1 Gaming music pack: '
+          'https://void1gaming.itch.io/free-synthwave-music-pack '
+          'See assets/audio/README.md for more information.');
+    }
 
     return super.onLoad();
   }
 
   void playBgm(String filename) {
+    if (!FlameAudio.audioCache.loadedFiles.containsKey(filename)) return;
+
     if (gameRef.buildContext != null) {
       if (Provider.of<Settings>(gameRef.buildContext!, listen: false)
           .backgroundMusic) {

--- a/lib/game/audio_player_component.dart
+++ b/lib/game/audio_player_component.dart
@@ -1,5 +1,4 @@
 import 'package:flame/components.dart';
-import 'package:flame/flame.dart';
 import 'package:flame_audio/flame_audio.dart';
 import 'package:provider/provider.dart';
 

--- a/lib/models/player_data.dart
+++ b/lib/models/player_data.dart
@@ -87,7 +87,7 @@ class PlayerData extends ChangeNotifier with HiveObjectMixin {
 
   /// Returns true if player's current spaceship type is same as given [SpaceshipType].
   bool isEquipped(SpaceshipType spaceshipType) {
-    return (spaceshipType == spaceshipType);
+    return (this.spaceshipType == spaceshipType);
   }
 
   /// Buys the given [SpaceshipType] if player has enough money and does not already own it.


### PR DESCRIPTION
- Windows doesn't work if we fail to load the background music.
  - Special case this and print a helpful developer log.
- PlayerData.isEquipped check is checking function parameter against
  itself, vs against the player data.


NOTE: I still have problems playing audio on Windows. Its buried deep in audioplayer_windows. I don't believe this is a result of spacescape.

```
AudioPlayers: Error setting url to '/C:/Users/john/AppData/Local/Temp/laser1.ogg'.
```

